### PR TITLE
Adds CocoaPods 1.2.0 to Travis (which provides 1.1.1 right now)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode7.3
+osx_image: xcode8.3
 
 language: objective-c
 cache: cocoapods

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
     - pod outdated | awk '{ if ( $1 ~ /^-/ ) { print $0 } }' | awk '{ if ( $3 != $5 ) { pod update $2 } else { print "No updated needed for" $2 } }'
 
 script:
-    - xcodebuild -workspace glucosio.xcworkspace -scheme glucosio -sdk iphonesimulator test | xcpretty -c
+    - xcodebuild -workspace glucosio.xcworkspace -scheme glucosio -destination 'name=iPhone 6s' test | xcpretty -c

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,8 @@ before_install:
     - gem install cocoapods -v 1.2.0
     - gem install xcpretty -N
 
+install:
+    - pod outdated | awk '{ if ( $1 ~ /^-/ ) { print $0 } }' | awk '{ if ( $3 != $5 ) { pod update $2 } else { print "No updated needed for" $2 } }'
+
 script:
     - xcodebuild -workspace glucosio.xcworkspace -scheme glucosio -sdk iphonesimulator test | xcpretty -c

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache: cocoapods
 podfile: Podfile
 
 before_install:
+    - gem install cocoapods -v 1.2.0
     - gem install xcpretty -N
 
 script:


### PR DESCRIPTION
Travis builds seems to be failing since we upgraded Cocoapods.

From the log I see they have 1.1.1 and according to [their documentation](https://docs.travis-ci.com/user/common-build-problems/#Newer-version-of-CocoaPods-required) we might need to manually install the newer version

Note how I kept adding commits because other things broke:

* pods not found
* the watchos dependency confusing xcodebuild 
* a newer XCode image needed for some frameworks

I'm pleased with the PR now. Please review.